### PR TITLE
fix: correct disclaimer import in PDF export

### DIFF
--- a/amalo/pdf_export.py
+++ b/amalo/pdf_export.py
@@ -4,7 +4,9 @@ from reportlab.lib.pagesizes import LETTER
 from reportlab.lib import colors
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
 from reportlab.lib.styles import getSampleStyleSheet
-from core.presets import DISCLAIMER
+# Use the local presets module rather than a non-existent external "core" package.
+# This ensures the `DISCLAIMER` constant is available when generating PDFs.
+from .presets import DISCLAIMER
 
 def build_prequal_pdf(out_path: str, branding: dict, summary: dict, incomes_table: list[list], warnings: list[dict], checklist: list[dict]):
     styles = getSampleStyleSheet()


### PR DESCRIPTION
## Summary
- fix module import path for disclaimer by referencing local presets module
- document reason for using local presets to avoid missing dependency

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ab7bb0c0833196a6994ff8add604