### PR TITLE
UI: W-2 forms + per-entry cards

### DIFF
--- a/tests/test_w2_ui.py
+++ b/tests/test_w2_ui.py
@@ -1,0 +1,15 @@
+from streamlit.testing.v1 import AppTest
+
+
+def w2_form_app():
+    import streamlit as st
+    import app
+    if "w2_rows" not in st.session_state:
+        st.session_state["w2_rows"] = []
+    app.render_w2_form()
+
+
+def test_w2_ui_smoke():
+    at = AppTest.from_function(w2_form_app)
+    at.run()
+    assert at.button("add_w2_job") is not None


### PR DESCRIPTION
## Summary
- replace W-2 editable table with per-job cards using forms and inline help
- show monthly income previews within each card
- add smoke test for W-2 UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6b5dfe7548331854beaccfee311c1