### PR TITLE
fix: avoid nested expanders in W2 form

### DIFF
--- a/app.py
+++ b/app.py
@@ -255,7 +255,8 @@ def render_w2_form():
         st.session_state["w2_rows"] = rows
     for idx, row in enumerate(rows):
         title = row.get("Employer") or f"Job {idx + 1}"
-        with st.expander(title, expanded=True):
+        with st.container():
+            st.subheader(title)
             form_key = f"w2_job_{idx}"
             with st.form(form_key):
                 cols = st.columns(3)


### PR DESCRIPTION
## Summary
- replace nested Streamlit expander in W2 form with container to prevent APIException

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc6e368083319f407bfdbf434ea0