### PR TITLE
Fix TypeError in W-2 remove button

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,7 +302,7 @@ def render_w2_form():
 
                 c1, c2 = st.columns(2)
                 save = c1.form_submit_button("Save")
-                remove = c2.form_submit_button("Remove", key=f"remove_{form_key}")
+                remove = c2.form_submit_button("Remove")
 
             if save:
                 rows[idx] = row

--- a/tests/test_w2_ui.py
+++ b/tests/test_w2_ui.py
@@ -1,4 +1,5 @@
 from streamlit.testing.v1 import AppTest
+from core.models import W2
 
 
 def w2_form_app():
@@ -11,5 +12,12 @@ def w2_form_app():
 
 def test_w2_ui_smoke():
     at = AppTest.from_function(w2_form_app)
+    at.run()
+    assert at.button("add_w2_job") is not None
+
+
+def test_w2_ui_with_row():
+    at = AppTest.from_function(w2_form_app)
+    at.session_state["w2_rows"] = [W2().model_dump()]
     at.run()
     assert at.button("add_w2_job") is not None


### PR DESCRIPTION
## Summary
- Remove unsupported key from Streamlit `form_submit_button` in W-2 form to prevent TypeError
- Add regression test to ensure W-2 form renders when a row is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6be7e9aa48331ac8f07ebdb9ad9ea