### PR TITLE
feat: enhance W-2 income validation and averaging

### DIFF
--- a/amalo/models.py
+++ b/amalo/models.py
@@ -17,6 +17,7 @@ class W2Row(BaseModel):
     Bonus_LY: float = 0.0
     Comm_LY: float = 0.0
     Months_LY: float = 0.0
+    VarAvgMonths: int = 12
     IncludeVariable: bool = False
 
 

--- a/core/models.py
+++ b/core/models.py
@@ -16,6 +16,7 @@ class W2(BaseModel):
     Bonus_LY: float = 0.0
     Comm_LY: float = 0.0
     Months_LY: float = 0.0
+    VarAvgMonths: int = 12
     IncludeVariable: bool = False
 
 


### PR DESCRIPTION
## Summary
- prevent negative W-2 inputs and show hourly workers' monthly base pay
- add 12 vs 24 month averaging for variable income with insufficient-history warning
- compute W-2 monthly income with negative-safe clipping and flag insufficient variable data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6bff5c43c833196e30c38c8a5ac34