### PR TITLE
Expand income policies and multi-borrower handling

### DIFF
--- a/core/calculators.py
+++ b/core/calculators.py
@@ -331,6 +331,32 @@ def rentals_policy(
         agg["Rental_DecliningFlag"] = False
         return agg[["BorrowerID", "Rental_Monthly", "Rental_DecliningFlag"]]
 
+
+def default_gross_up_pct(income_type: str, program: str) -> float:
+    """Return recommended gross-up percentage for common non-taxable income.
+
+    The defaults reflect typical FHA/VA/Conventional guidelines.  Only a few
+    income types are recognized; all others return ``0`` meaning no gross-up is
+    suggested.
+    """
+
+    itype = (income_type or "").lower()
+    prog = (program or "").lower()
+    if "social" in itype:
+        return 25.0
+    if "disability" in itype:
+        return 15.0
+    return 0.0
+
+
+def filter_support_income(df: pd.DataFrame, continuance_ok: bool) -> pd.DataFrame:
+    """Exclude support or housing allowance income when continuance not met."""
+
+    if continuance_ok or df is None or df.empty:
+        return df
+    mask = ~df["Type"].astype(str).str.lower().str.contains("alimony|child|housing", regex=True)
+    return df[mask]
+
 def other_income_totals(df: pd.DataFrame) -> pd.DataFrame:
     """Aggregate miscellaneous income sources such as alimony or SSA.
 


### PR DESCRIPTION
## Summary
- add PITIA support and method highlighting for rental income policy
- default gross-up percentages and continuance filtering for other income
- allow up to four borrowers with per-borrower totals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6c47c6054833198cd0e61a8df4258