### PR TITLE
Add real-time P&I calculator to housing tab

### DIFF
--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from core.presets import (
     VA_TABLE,
     USDA_TABLE,
 )
-from core.calculators import piti_components, dti
+from core.calculators import piti_components, dti, monthly_payment
 from core.models import W2
 from ui.topbar import render_topbar
 from ui.cards_income import render_income_cards
@@ -40,6 +40,13 @@ def render_property_column():
         h["down_payment_amt"] = st.number_input("Down Payment", value=float(h.get("down_payment_amt", 0.0)))
         h["rate_pct"] = st.number_input("Rate %", value=float(h.get("rate_pct", 0.0)))
         h["term_years"] = st.number_input("Term (years)", value=float(h.get("term_years", 30)))
+        base_loan = h.get("purchase_price", 0.0) - h.get("down_payment_amt", 0.0)
+        pi_only = monthly_payment(
+            base_loan,
+            h.get("rate_pct", 0.0),
+            h.get("term_years", 30),
+        )
+        st.caption(f"Monthly P&I: ${pi_only:,.2f}")
         h["tax_rate_pct"] = st.number_input("Tax Rate %", value=float(h.get("tax_rate_pct", 0.0)))
         h["hoi_annual"] = st.number_input("HOI Annual", value=float(h.get("hoi_annual", 0.0)))
         h["hoa_monthly"] = st.number_input("HOA Monthly", value=float(h.get("hoa_monthly", 0.0)))

--- a/tests/test_payment_ui.py
+++ b/tests/test_payment_ui.py
@@ -1,0 +1,36 @@
+from streamlit.testing.v1 import AppTest
+from core.calculators import monthly_payment
+
+
+def housing_app():
+    import streamlit as st
+    import app
+    app.render_property_column()
+
+
+def test_pi_calculator_updates():
+    at = AppTest.from_function(housing_app)
+    at.session_state["housing"] = {
+        "purchase_price": 100000.0,
+        "down_payment_amt": 20000.0,
+        "rate_pct": 5.0,
+        "term_years": 30,
+        "tax_rate_pct": 0.0,
+        "hoi_annual": 0.0,
+        "hoa_monthly": 0.0,
+        "finance_upfront": True,
+    }
+    at.run()
+    base_loan = 80000.0
+    expected = monthly_payment(base_loan, 5.0, 30)
+    pi_caption = next(c.value for c in at.caption if c.value.startswith("Monthly P&I"))
+    assert pi_caption == f"Monthly P&I: ${expected:,.2f}"
+
+    rate_widget = next(w for w in at.number_input if w.label == "Rate %")
+    term_widget = next(w for w in at.number_input if w.label == "Term (years)")
+    rate_widget.set_value(7.0)
+    term_widget.set_value(15)
+    at.run()
+    expected2 = monthly_payment(base_loan, 7.0, 15)
+    pi_caption2 = next(c.value for c in at.caption if c.value.startswith("Monthly P&I"))
+    assert pi_caption2 == f"Monthly P&I: ${expected2:,.2f}"


### PR DESCRIPTION
## Summary
- show monthly principal & interest in Payment & Housing tab
- allow interactive updates when rate or term changes
- test P&I caption responds to rate and term adjustments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6cf5fd8b88331816b06f680176372