### PR TITLE
Add HOI percentage input with Florida field tips

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,9 +47,29 @@ def render_property_column():
             h.get("term_years", 30),
         )
         st.caption(f"Monthly P&I: ${pi_only:,.2f}")
-        h["tax_rate_pct"] = st.number_input("Tax Rate %", value=float(h.get("tax_rate_pct", 0.0)))
-        h["hoi_annual"] = st.number_input("HOI Annual", value=float(h.get("hoi_annual", 0.0)))
-        h["hoa_monthly"] = st.number_input("HOA Monthly", value=float(h.get("hoa_monthly", 0.0)))
+        h["tax_rate_pct"] = st.number_input(
+            "Tax Rate %",
+            value=float(h.get("tax_rate_pct", 0.0)),
+            help="Avg Florida property tax ~1% of purchase price",
+        )
+        h["hoi_rate_pct"] = st.number_input(
+            "HOI Rate %",
+            value=float(h.get("hoi_rate_pct", 0.0)),
+            help="Enter as % of purchase price (FL avg ~1%)",
+        )
+        h["hoi_annual"] = st.number_input(
+            "HOI Annual",
+            value=float(h.get("hoi_annual", 0.0)),
+            help="Annual homeowners insurance amount",
+        )
+        if h.get("hoi_rate_pct", 0.0) > 0:
+            h["hoi_annual"] = h.get("purchase_price", 0.0) * h["hoi_rate_pct"] / 100
+            st.caption(f"Calculated HOI Annual: ${h['hoi_annual']:,.2f}")
+        h["hoa_monthly"] = st.number_input(
+            "HOA Monthly",
+            value=float(h.get("hoa_monthly", 0.0)),
+            help="Florida HOA averages ~$250/mo",
+        )
         h["finance_upfront"] = st.checkbox("Finance Upfront Fees", value=bool(h.get("finance_upfront", True)))
     base_loan = h.get("purchase_price", 0.0) - h.get("down_payment_amt", 0.0)
     comps = piti_components(

--- a/tests/test_payment_ui.py
+++ b/tests/test_payment_ui.py
@@ -34,3 +34,21 @@ def test_pi_calculator_updates():
     expected2 = monthly_payment(base_loan, 7.0, 15)
     pi_caption2 = next(c.value for c in at.caption if c.value.startswith("Monthly P&I"))
     assert pi_caption2 == f"Monthly P&I: ${expected2:,.2f}"
+
+
+def test_hoi_rate_pct_used_for_annual():
+    at = AppTest.from_function(housing_app)
+    at.session_state["housing"] = {
+        "purchase_price": 200000.0,
+        "down_payment_amt": 0.0,
+        "rate_pct": 5.0,
+        "term_years": 30,
+        "tax_rate_pct": 0.0,
+        "hoi_annual": 0.0,
+        "hoi_rate_pct": 1.0,
+        "hoa_monthly": 0.0,
+        "finance_upfront": True,
+    }
+    at.run()
+    expected_hoi = 200000.0 * 1.0 / 100 / 12
+    assert abs(at.session_state["housing_calc"]["hoi"] - expected_hoi) < 1e-6


### PR DESCRIPTION
## Summary
- Support estimating homeowners insurance from a percentage rate
- Provide helpful Florida averages for tax, insurance, and HOA fields
- Test HOI percent conversion in housing payment UI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d2e5ed6c8331b13eccbd6e66d06b