### PR TITLE
feat: add editable MI tables and sidebar editor

### DIFF
--- a/core/calculators.py
+++ b/core/calculators.py
@@ -464,15 +464,23 @@ def compute_ltv(purchase_price, base_loan):
 def conventional_mi_factor(ltv, fico_bucket, mi_table):
     """Look up private MI factor based on LTV and credit score bucket."""
 
+    bucket_tbl = {}
+    if isinstance(mi_table, dict):
+        bucket_tbl = mi_table.get(fico_bucket) or mi_table.get("default")
+        if bucket_tbl is None and mi_table:
+            # fall back to first entry
+            bucket_tbl = next(iter(mi_table.values()))
+    bucket_tbl = bucket_tbl or {}
+
     if ltv >= 97:
-        return mi_table.get(">=97", 0.90)
+        return bucket_tbl.get(">=97", 0.90)
     if 95 <= ltv < 97:
-        return mi_table.get("95-97", 0.62)
+        return bucket_tbl.get("95-97", 0.62)
     if 90 <= ltv < 95:
-        return mi_table.get("90-95", 0.40)
+        return bucket_tbl.get("90-95", 0.40)
     if 85 <= ltv < 90:
-        return mi_table.get("85-90", 0.25)
-    return mi_table.get("<85", 0.0)
+        return bucket_tbl.get("85-90", 0.25)
+    return bucket_tbl.get("<85", 0.0)
 
 
 def fha_mip_factor(ltv, term_years, table):

--- a/core/presets.py
+++ b/core/presets.py
@@ -7,7 +7,14 @@ DISCLAIMER = ("This tool implements common calculations aligned with agency/inve
 PROGRAM_PRESETS = {"Conventional":{"FE":31.0,"BE":45.0},"FHA":{"FE":31.0,"BE":50.0},
 "VA":{"FE":35.0,"BE":50.0},"USDA":{"FE":29.0,"BE":41.0},"Jumbo":{"FE":35.0,"BE":43.0}}
 
-CONV_MI_BANDS = {">=97":0.90,"95-97":0.62,"90-95":0.40,"85-90":0.25,"<85":0.00}
+# Conventional MI factors by FICO bucket and LTV band. Values represent the
+# annual private mortgage insurance percentage.  Default values are fairly
+# generic but can be tailored by the user via the sidebar UI.
+CONV_MI_BANDS = {
+    "760+": {">=97": 0.90, "95-97": 0.62, "90-95": 0.40, "85-90": 0.25, "<85": 0.00},
+    "720-759": {">=97": 0.90, "95-97": 0.62, "90-95": 0.40, "85-90": 0.25, "<85": 0.00},
+    "<720": {">=97": 0.90, "95-97": 0.62, "90-95": 0.40, "85-90": 0.25, "<85": 0.00},
+}
 FHA_TABLES = {"ufmip_pct":1.75,"annual_table":{"<=95_<=15":0.15,"<=95_>15":0.50,">95_<=15":0.40,">95_>15":0.55}}
 VA_TABLE = {"first_0_5":2.15,"first_5_10":1.50,"first_10+":1.25,"subseq_0_5":3.30,"subseq_5_10":1.50,"subseq_10+":1.25}
 USDA_TABLE = {"guarantee_pct":1.0,"annual_pct":0.35}

--- a/tests/test_fee_sidebar.py
+++ b/tests/test_fee_sidebar.py
@@ -1,0 +1,38 @@
+import json
+from streamlit.testing.v1 import AppTest
+
+
+def sidebar_app():
+    import app
+    app.render_fee_sidebar()
+    app.render_property_column()
+
+
+def test_conventional_mi_table_editable():
+    at = AppTest.from_function(sidebar_app)
+    at.session_state["program_name"] = "Conventional"
+    at.session_state["housing"] = {
+        "purchase_price": 200000.0,
+        "down_payment_amt": 20000.0,
+        "rate_pct": 5.0,
+        "term_years": 30,
+        "tax_rate_pct": 0.0,
+        "hoi_annual": 0.0,
+        "hoa_monthly": 0.0,
+        "finance_upfront": True,
+        "credit_score": 700,
+    }
+    at.run()
+    base_loan = 180000.0
+    default_mi = at.session_state["housing_calc"]["mi"]
+    assert abs(default_mi - base_loan * (0.40 / 100) / 12) < 1e-6
+
+    # modify the sidebar table for the <720 fico bucket and rerun
+    ta = next(w for w in at.sidebar.text_area if w.label == "Conventional MI Table")
+    tbl = at.session_state["conv_mi_table"]
+    tbl["<720"]["90-95"] = 1.00
+    ta.set_value(json.dumps(tbl, indent=2))
+    at.run()
+    updated_mi = at.session_state["housing_calc"]["mi"]
+    assert abs(updated_mi - base_loan * (1.00 / 100) / 12) < 1e-6
+    assert updated_mi != default_mi


### PR DESCRIPTION
## Summary
- allow editing MI/MIP/guarantee tables in sidebar
- compute conventional MI by credit score buckets
- test sidebar updates to MI calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d41d90548331b315c1dafdcafd24