### PR TITLE
feat(ui): organize cards into two columns with field guidance

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,8 +25,14 @@ def render_w2_form():
         st.session_state.w2_rows.append(W2().model_dump())
     for idx, row in enumerate(st.session_state.w2_rows):
         with st.expander(f"W2 #{idx+1}"):
-            for field, val in row.items():
-                st.text_input(field, value=str(val), key=f"w2_{idx}_{field}")
+            items = list(row.items())
+            for i in range(0, len(items), 2):
+                cols = st.columns(2)
+                for col_idx, (field, val) in enumerate(items[i : i + 2]):
+                    with cols[col_idx]:
+                        st.markdown(f"**{field}**")
+                        st.caption(f"Enter {field}")
+                        st.text_input("", value=str(val), key=f"w2_{idx}_{field}")
 
 
 def fico_to_bucket(score):

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -31,11 +31,18 @@ def render_debt_cards() -> float:
                 card["type"] = sel
                 card["payload"] = _default_payload(sel)
             payload = card["payload"]
-            for f, v in payload.items():
-                if isinstance(v, (int, float)):
-                    payload[f] = st.number_input(f, value=float(v), key=f"debt_{idx}_{f}")
-                else:
-                    payload[f] = st.text_input(f, value=v, key=f"debt_{idx}_{f}")
+            items = list(payload.items())
+            for i in range(0, len(items), 2):
+                cols = st.columns(2)
+                for col_idx, (f, v) in enumerate(items[i : i + 2]):
+                    with cols[col_idx]:
+                        label = f.replace("_", " ").title()
+                        st.markdown(f"**{label}**")
+                        st.caption(f"Enter {label}")
+                        if isinstance(v, (int, float)):
+                            payload[f] = st.number_input("", value=float(v), key=f"debt_{idx}_{f}")
+                        else:
+                            payload[f] = st.text_input("", value=v, key=f"debt_{idx}_{f}")
             preview = float(payload.get("monthly_payment", 0))
             st.caption(f"Monthly Payment: ${preview:,.2f}")
             c1, c2 = st.columns(2)

--- a/ui/cards_income.py
+++ b/ui/cards_income.py
@@ -45,11 +45,25 @@ def render_income_cards() -> float:
                 card["type"] = sel
                 card["payload"] = _default_payload(sel)
             payload = card["payload"]
-            for f, v in payload.items():
-                if isinstance(v, (int, float)):
-                    payload[f] = st.number_input(f, value=float(v), key=f"inc_{idx}_{f}")
-                else:
-                    payload[f] = st.text_input(f, value=v, key=f"inc_{idx}_{f}")
+            model_cls = INCOME_MODELS[card["type"]][1]
+            items = list(payload.items())
+            for i in range(0, len(items), 2):
+                cols = st.columns(2)
+                for col_idx, (f, v) in enumerate(items[i : i + 2]):
+                    with cols[col_idx]:
+                        st.markdown(f"**{f}**")
+                        desc = ""
+                        try:
+                            desc = model_cls.model_fields[f].description or ""
+                        except Exception:
+                            pass
+                        if not desc:
+                            desc = f"Enter {f.replace('_', ' ')}"
+                        st.caption(desc)
+                        if isinstance(v, (int, float)):
+                            payload[f] = st.number_input("", value=float(v), key=f"inc_{idx}_{f}")
+                        else:
+                            payload[f] = st.text_input("", value=v, key=f"inc_{idx}_{f}")
             preview = _monthly_preview(card)
             st.caption(f"Monthly Qualifying: ${preview:,.2f}")
             c1, c2 = st.columns(2)


### PR DESCRIPTION
## Summary
- Arrange income and debt card fields in two-column layouts
- Show brief descriptions beneath field titles before inputs
- Apply consistent two-column layout to W-2 form entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6d61f27c883319aa2b191fe31da0d