### PR TITLE
docs: add changelog and update agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,5 @@
 - Keep changes focused and grouped into logical commits.
 - Use `render_income_tab` for new Streamlit form groups.
 - Default branch is `main`; avoid creating new branches.
+- When implementing new features, verify that existing functionality remains unaffected and add or update tests accordingly.
+- Record each change in `CHANGELOG.md` with a brief summary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Project guidelines for maintaining a changelog and adding tests for new features.
 - Initial `CHANGELOG.md` file.
+- Test ensuring the changelog contains at least one entry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2025-08-21]
+### Added
+- Project guidelines for maintaining a changelog and adding tests for new features.
+- Initial `CHANGELOG.md` file.

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,11 @@
+import os
+
+
+def test_changelog_has_entries():
+    root = os.path.dirname(os.path.dirname(__file__))
+    changelog = os.path.join(root, 'CHANGELOG.md')
+    assert os.path.exists(changelog), 'CHANGELOG.md should exist'
+    with open(changelog) as f:
+        lines = f.readlines()
+    entries = [line for line in lines if line.strip().startswith('- ')]
+    assert entries, 'CHANGELOG.md should contain at least one bullet entry'


### PR DESCRIPTION
## Summary
- update AGENTS.md to require changelog entries and regression tests
- add initial CHANGELOG.md for tracking modifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6d95721f8833188f898f34fcbae22