### PR TITLE
Add max qualifier solver and debt payoff option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,9 @@ All notable changes to this project will be documented in this file.
 - Project guidelines for maintaining a changelog and adding tests for new features.
 - Initial `CHANGELOG.md` file.
 - Test ensuring the changelog contains at least one entry.
+
+## [2025-08-22]
+### Added
+- Debt cards can be marked for payoff at closing and excluded from DTI.
+- Upfront fees now adjust loan amount and LTV when financed.
+- Max qualifiers solver computes maximum loan given DTI and cash inputs.

--- a/core/calculators.py
+++ b/core/calculators.py
@@ -546,20 +546,23 @@ def apply_program_fees(
         ann_pct = fha_mip_factor(ltv, term_years, fha_tables.get("annual_table", {}))
         upfront = base_loan * (uf_pct / 100)
         adj = base_loan + upfront if finance_upfront else base_loan
+        ltv_calc = compute_ltv(purchase_price, adj) if finance_upfront else ltv
         mi_monthly = adj * (ann_pct / 100) / 12
-        return {"adjusted_loan": adj, "mi_monthly": mi_monthly, "upfront_amt": upfront, "ltv": ltv}
+        return {"adjusted_loan": adj, "mi_monthly": mi_monthly, "upfront_amt": upfront, "ltv": ltv_calc}
     if program == "VA":
         fee_pct = va_funding_fee_pct(first_use_va, down_pct, va_tbl)
         upfront = base_loan * (fee_pct / 100)
         adj = base_loan + upfront if finance_upfront else base_loan
-        return {"adjusted_loan": adj, "mi_monthly": 0.0, "upfront_amt": upfront, "ltv": ltv}
+        ltv_calc = compute_ltv(purchase_price, adj) if finance_upfront else ltv
+        return {"adjusted_loan": adj, "mi_monthly": 0.0, "upfront_amt": upfront, "ltv": ltv_calc}
     if program == "USDA":
         g_pct = usda_guarantee_pct(usda_tbl)
         upfront = base_loan * (g_pct / 100)
         adj = base_loan + upfront if finance_upfront else base_loan
         ann_pct = usda_annual_fee_pct(usda_tbl)
         mi_monthly = adj * (ann_pct / 100) / 12
-        return {"adjusted_loan": adj, "mi_monthly": mi_monthly, "upfront_amt": upfront, "ltv": ltv}
+        ltv_calc = compute_ltv(purchase_price, adj) if finance_upfront else ltv
+        return {"adjusted_loan": adj, "mi_monthly": mi_monthly, "upfront_amt": upfront, "ltv": ltv_calc}
     return {"adjusted_loan": base_loan, "mi_monthly": 0.0, "upfront_amt": 0.0, "ltv": ltv}
 
 
@@ -637,3 +640,83 @@ def max_affordable_pi(
     fe_max = max(0.0, inc * nz(target_fe_pct) / 100 - nz(taxes_ins_hoa_mi))
     be_max = max(0.0, inc * nz(target_be_pct) / 100 - nz(other_liabilities))
     return fe_max, be_max, min(fe_max, be_max)
+
+
+def max_qualifying_loan(
+    total_income,
+    other_liabilities,
+    taxes_ins_hoa_mi,
+    target_fe_pct,
+    target_be_pct,
+    rate_pct,
+    term_years,
+    down_payment_amt,
+    program,
+    conv_mi_tbl,
+    fha_tables,
+    va_tbl,
+    usda_tbl,
+    finance_upfront,
+    first_use_va,
+    fico_bucket,
+    iterations: int = 20,
+):
+    """Solve for maximum loan amount given DTI targets and cash to close."""
+
+    fe_max, be_max, pi_allowed = max_affordable_pi(
+        total_income, other_liabilities, taxes_ins_hoa_mi, target_fe_pct, target_be_pct
+    )
+    if pi_allowed <= 0:
+        return {
+            "max_pi": 0.0,
+            "base_loan": 0.0,
+            "adjusted_loan": 0.0,
+            "purchase_price": down_payment_amt,
+        }
+
+    adj_limit = principal_from_payment(pi_allowed, rate_pct, term_years)
+    low, high = 0.0, adj_limit
+    for _ in range(iterations):
+        mid = (low + high) / 2
+        fees = apply_program_fees(
+            program,
+            mid + down_payment_amt,
+            mid,
+            down_payment_amt,
+            rate_pct,
+            term_years,
+            conv_mi_tbl,
+            fha_tables,
+            va_tbl,
+            usda_tbl,
+            finance_upfront,
+            first_use_va,
+            fico_bucket,
+        )
+        if fees["adjusted_loan"] > adj_limit:
+            high = mid
+        else:
+            low = mid
+    base = low
+    purchase_price = base + down_payment_amt
+    fees = apply_program_fees(
+        program,
+        purchase_price,
+        base,
+        down_payment_amt,
+        rate_pct,
+        term_years,
+        conv_mi_tbl,
+        fha_tables,
+        va_tbl,
+        usda_tbl,
+        finance_upfront,
+        first_use_va,
+        fico_bucket,
+    )
+    return {
+        "max_pi": pi_allowed,
+        "base_loan": base,
+        "adjusted_loan": fees["adjusted_loan"],
+        "purchase_price": purchase_price,
+    }

--- a/tests/test_calculators.py
+++ b/tests/test_calculators.py
@@ -8,6 +8,7 @@ from core.calculators import (
     monthly_payment,
     principal_from_payment,
     max_affordable_pi,
+    max_qualifying_loan,
     rentals_policy,
     default_gross_up_pct,
     filter_support_income,
@@ -32,6 +33,48 @@ def test_max_affordable_pi():
     fe, be, cons = max_affordable_pi(12000, 500, 800, 31, 45)
     assert cons <= fe and cons <= be
     assert cons >= 0
+
+
+def test_max_qualifying_loan_fha_financed():
+    res = max_qualifying_loan(
+        10000,
+        500,
+        300,
+        31,
+        45,
+        6.5,
+        30,
+        20000,
+        "FHA",
+        CONV_MI_BANDS,
+        FHA_TABLES,
+        VA_TABLE,
+        USDA_TABLE,
+        True,
+        True,
+        ">=740",
+    )
+    assert res["adjusted_loan"] >= res["base_loan"]
+    assert abs(res["purchase_price"] - (res["base_loan"] + 20000)) < 1e-6
+
+
+def test_apply_program_fees_financed_ltv():
+    res = apply_program_fees(
+        "FHA",
+        300000,
+        285000,
+        15000,
+        6.5,
+        30,
+        CONV_MI_BANDS,
+        FHA_TABLES,
+        VA_TABLE,
+        USDA_TABLE,
+        True,
+        True,
+        ">=740",
+    )
+    assert abs(res["ltv"] - (res["adjusted_loan"] / 300000 * 100)) < 1e-6
 
 
 def test_rentals_policy_schedule_e():

--- a/tests/test_debts_ui.py
+++ b/tests/test_debts_ui.py
@@ -1,0 +1,18 @@
+from streamlit.testing.v1 import AppTest
+
+
+def debts_app():
+    import streamlit as st
+    from ui.cards_debts import render_debt_cards
+    render_debt_cards()
+
+
+def test_payoff_flag_excludes_from_total():
+    at = AppTest.from_function(debts_app)
+    at.session_state["debt_cards"] = [
+        {"type": "installment", "payload": {"name": "A", "monthly_payment": 100.0, "remaining_payments": 0, "payoff_at_close": True}},
+        {"type": "installment", "payload": {"name": "B", "monthly_payment": 200.0, "remaining_payments": 0, "payoff_at_close": False}},
+    ]
+    at.run()
+    md = next(m.value for m in at.markdown if "Total Monthly Debts" in m.value)
+    assert "$200.00" in md

--- a/tests/test_payment_ui.py
+++ b/tests/test_payment_ui.py
@@ -52,3 +52,22 @@ def test_hoi_rate_pct_used_for_annual():
     at.run()
     expected_hoi = 200000.0 * 1.0 / 100 / 12
     assert abs(at.session_state["housing_calc"]["hoi"] - expected_hoi) < 1e-6
+
+
+def test_financed_fee_displays_adjusted_loan():
+    at = AppTest.from_function(housing_app)
+    at.session_state["program_name"] = "FHA"
+    at.session_state["housing"] = {
+        "purchase_price": 200000.0,
+        "down_payment_amt": 10000.0,
+        "rate_pct": 5.0,
+        "term_years": 30,
+        "tax_rate_pct": 0.0,
+        "hoi_annual": 0.0,
+        "hoa_monthly": 0.0,
+        "finance_upfront": True,
+        "first_use_va": True,
+    }
+    at.run()
+    caption = next(c.value for c in at.caption if "Base Loan" in c.value)
+    assert "Adjusted Loan" in caption

--- a/ui/bottombar.py
+++ b/ui/bottombar.py
@@ -26,5 +26,7 @@ def render_bottombar(summary: dict, enabled: bool):
         if cols[4].button("Open Dashboard"):
             st.session_state["view_mode"] = "dashboard"
             st.experimental_rerun()
-        cols[5].button("Open Max Qualifiers")
+        if cols[5].button("Open Max Qualifiers"):
+            st.session_state["view_mode"] = "max_qualifiers"
+            st.experimental_rerun()
         st.markdown("</div>", unsafe_allow_html=True)

--- a/ui/cards_debts.py
+++ b/ui/cards_debts.py
@@ -2,10 +2,20 @@ import copy
 import streamlit as st
 
 DEBT_MODELS = {
-    "installment": {"name": "", "monthly_payment": 0.0, "remaining_payments": 0},
-    "revolving": {"name": "", "monthly_payment": 0.0},
-    "student_loan": {"name": "", "monthly_payment": 0.0, "balance": 0.0},
-    "support": {"name": "", "monthly_payment": 0.0},
+    "installment": {
+        "name": "",
+        "monthly_payment": 0.0,
+        "remaining_payments": 0,
+        "payoff_at_close": False,
+    },
+    "revolving": {"name": "", "monthly_payment": 0.0, "payoff_at_close": False},
+    "student_loan": {
+        "name": "",
+        "monthly_payment": 0.0,
+        "balance": 0.0,
+        "payoff_at_close": False,
+    },
+    "support": {"name": "", "monthly_payment": 0.0, "payoff_at_close": False},
 }
 
 
@@ -39,7 +49,9 @@ def render_debt_cards() -> float:
                         label = f.replace("_", " ").title()
                         st.markdown(f"**{label}**")
                         st.caption(f"Enter {label}")
-                        if isinstance(v, (int, float)):
+                        if isinstance(v, bool):
+                            payload[f] = st.checkbox("", value=v, key=f"debt_{idx}_{f}")
+                        elif isinstance(v, (int, float)):
                             payload[f] = st.number_input("", value=float(v), key=f"debt_{idx}_{f}")
                         else:
                             payload[f] = st.text_input("", value=v, key=f"debt_{idx}_{f}")
@@ -52,6 +64,7 @@ def render_debt_cards() -> float:
             if c2.button("Duplicate", key=f"debt_dup_{idx}"):
                 st.session_state.debt_cards.append(copy.deepcopy(card))
                 st.experimental_rerun()
-        total += float(card["payload"].get("monthly_payment", 0))
+        if not card["payload"].get("payoff_at_close", False):
+            total += float(card["payload"].get("monthly_payment", 0))
     st.markdown(f"**Total Monthly Debts:** ${total:,.2f}")
     return total

--- a/ui/max_qualifiers.py
+++ b/ui/max_qualifiers.py
@@ -1,0 +1,38 @@
+import streamlit as st
+from core.calculators import max_qualifying_loan
+from core.presets import CONV_MI_BANDS, FHA_TABLES, VA_TABLE, USDA_TABLE
+from app import fico_to_bucket
+
+
+def render_max_qualifiers_view():
+    """Render the max qualifiers solver interface."""
+    st.header("Max Qualifiers")
+    tot_inc = st.number_input("Total Monthly Income", value=0.0, key="mq_inc")
+    other_debts = st.number_input("Other Monthly Debts", value=0.0, key="mq_debts")
+    tax_ins = st.number_input("Taxes/Ins/HOA/MI", value=0.0, key="mq_ti")
+    rate = st.number_input("Rate %", value=0.0, key="mq_rate")
+    term = st.number_input("Term (years)", value=30.0, key="mq_term")
+    down = st.number_input("Down Payment", value=0.0, key="mq_down")
+    program = st.session_state.get("program_name", "Conventional")
+    targets = st.session_state.get("program_targets", {"fe_target": 0.0, "be_target": 0.0})
+    res = max_qualifying_loan(
+        tot_inc,
+        other_debts,
+        tax_ins,
+        targets.get("fe_target", 0.0),
+        targets.get("be_target", 0.0),
+        rate,
+        term,
+        down,
+        program,
+        st.session_state.get("conv_mi_table", CONV_MI_BANDS),
+        st.session_state.get("fha_table", FHA_TABLES),
+        st.session_state.get("va_table", VA_TABLE),
+        st.session_state.get("usda_table", USDA_TABLE),
+        True,
+        True,
+        fico_to_bucket(st.session_state.get("housing", {}).get("credit_score")),
+    )
+    st.caption(
+        f"Base Loan: ${res['base_loan']:,.0f} • Adjusted Loan: ${res['adjusted_loan']:,.0f} • Purchase Price: ${res['purchase_price']:,.0f}"
+    )

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -31,7 +31,7 @@ def render_topbar():
                 st.session_state["be_target"] = be
             tgt = {"fe_target": fe, "be_target": be}
         with right:
-            view_mode = st.radio("View", ["data_entry", "dashboard"], horizontal=True, key="view_mode")
+            view_mode = st.radio("View", ["data_entry", "dashboard", "max_qualifiers"], horizontal=True, key="view_mode")
             st.session_state.setdefault("ui_prefs", {})
             st.session_state["ui_prefs"].setdefault("language", "en")
             st.session_state["ui_prefs"]["language"] = st.selectbox("Lang", ["en", "es"], key="ui_lang", index=["en","es"].index(st.session_state["ui_prefs"].get("language","en")))


### PR DESCRIPTION
## Summary
- allow debts to be flagged for payoff so they are excluded from DTI
- account for financed upfront fees when computing loan and LTV and display adjusted loan
- add max qualifier solver to estimate maximum affordable loan

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6dbb5efbc8331b3a2c68c1d755d77