### PR TITLE
Enhance rules engine for income and DTI checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ All notable changes to this project will be documented in this file.
 - Debt cards can be marked for payoff at closing and excluded from DTI.
 - Upfront fees now adjust loan amount and LTV when financed.
 - Max qualifiers solver computes maximum loan given DTI and cash inputs.
+
+## [2025-08-23]
+### Added
+- Expanded rules engine to flag missing variable income months, total income declines, negative rental income, DTI limit breaches, and reserve prompts.

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,36 @@
+import pytest
+from core.rules import evaluate_rules
+
+
+def _codes(state):
+    return {r.code for r in evaluate_rules(state)}
+
+
+def test_missing_variable_months():
+    codes = _codes({"total_income": 1000, "w2_meta": {"var_missing_months": 2}})
+    assert "W2_VAR_MISSING_MONTHS" in codes
+
+
+def test_total_income_decline():
+    state = {"total_income": 1000, "total_income_history": {2023: 100000, 2024: 75000}}
+    codes = _codes(state)
+    assert "TOTAL_INCOME_DECLINE" in codes
+
+
+def test_negative_rental_income():
+    codes = _codes({"total_income": 1000, "rental_income": -50})
+    assert "RENTAL_INCOME_NEGATIVE" in codes
+
+
+def test_ratio_and_dti_limits():
+    state = {"total_income": 1000, "FE": 0.35, "BE": 0.5, "target_FE": 31, "target_BE": 45}
+    codes = _codes(state)
+    assert "HOUSING_RATIO_OVER_LIMIT" in codes
+    assert "TOTAL_DTI_OVER_LIMIT" in codes
+
+
+def test_reserves_prompt():
+    state_high_dti = {"total_income": 1000, "BE": 0.5}
+    state_invest = {"total_income": 1000, "is_investment_property": True}
+    assert "CONSIDER_RESERVES" in _codes(state_high_dti)
+    assert "CONSIDER_RESERVES" in _codes(state_invest)


### PR DESCRIPTION
## Summary
- warn when variable W-2 income history has missing months
- detect total income drops over 20% year-over-year
- flag negative rental income, DTI and housing ratio limit breaches, and prompt for reserves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6dfbb61908331990ad23e4040782f