### PR TITLE
feat: add document checklist builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,7 @@ All notable changes to this project will be documented in this file.
 ## [2025-08-23]
 ### Added
 - Expanded rules engine to flag missing variable income months, total income declines, negative rental income, DTI limit breaches, and reserve prompts.
+
+## [2025-08-24]
+### Added
+- Document checklist builder with checkboxes and PDF export support.

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from ui.topbar import render_topbar
 from ui.cards_income import render_income_cards
 from ui.cards_debts import render_debt_cards
 from ui.bottombar import render_bottombar
+from ui.documents import render_document_checklist
 
 
 # ---------------------------------------------------------------------------
@@ -232,6 +233,7 @@ def main():
             debt_total = render_debt_cards()
         with cols[2]:
             housing = render_property_column()
+            render_document_checklist()
         fe, be = dti(housing["total"], housing["total"] + debt_total, income_total)
         summary = {
             "total_income": income_total,

--- a/core/checklist.py
+++ b/core/checklist.py
@@ -1,0 +1,36 @@
+"""Document checklist helpers."""
+from __future__ import annotations
+from typing import List, Dict
+
+# Mapping of income card types to required documents
+DOCS_BY_TYPE: Dict[str, List[str]] = {
+    "w2": ["Last two pay stubs", "W-2s"],
+    "schc": ["1040s", "Business bank statements"],
+    "k1": ["1040s", "K-1s"],
+    "c1120": ["1040s", "Business bank statements"],
+    "rental": ["1040s", "Leases"],
+}
+
+
+def _docs_for_other(payload: Dict) -> List[str]:
+    t = str(payload.get("Type", "")).lower()
+    if "child" in t:
+        return ["Child support court orders"]
+    return ["Proof of other income"]
+
+
+def _docs_for_card(card: Dict) -> List[str]:
+    t = card.get("type")
+    if t == "other":
+        return _docs_for_other(card.get("payload", {}))
+    return DOCS_BY_TYPE.get(t, [])
+
+
+def build_document_checklist(income_cards: List[Dict]) -> List[str]:
+    """Return a de-duplicated list of required documents."""
+    docs: List[str] = []
+    for card in income_cards:
+        for doc in _docs_for_card(card):
+            if doc not in docs:
+                docs.append(doc)
+    return docs

--- a/export/pdf_export.py
+++ b/export/pdf_export.py
@@ -8,8 +8,12 @@ from core.presets import DISCLAIMER
 def build_prequal_pdf(data: Dict[str, Any]) -> bytes:
     """Build a prequalification PDF from provided data.
 
-    This is currently a stub implementation used for testing and development
-    purposes. It returns an empty byte string and does not generate a real PDF.
+    This stub encodes the documentation checklist into a plain text payload with
+    simple checkboxes. A real PDF implementation will replace this later.
     """
-    # Placeholder implementation; real PDF generation will be implemented later.
-    return b""
+    checklist = data.get("checklist", [])
+    lines = ["Documentation Checklist:"]
+    for item in checklist:
+        box = "[x]" if item.get("checked") else "[ ]"
+        lines.append(f"{box} {item.get('label', '')}")
+    return "\n".join(lines).encode()

--- a/tests/test_checklist.py
+++ b/tests/test_checklist.py
@@ -1,0 +1,29 @@
+from core.checklist import build_document_checklist
+from export.pdf_export import build_prequal_pdf
+
+
+def test_build_document_checklist():
+    income_cards = [
+        {"type": "w2", "payload": {}},
+        {"type": "schc", "payload": {}},
+        {"type": "other", "payload": {"Type": "Child Support"}},
+    ]
+    docs = build_document_checklist(income_cards)
+    assert "Last two pay stubs" in docs
+    assert "W-2s" in docs
+    assert "1040s" in docs
+    assert "Business bank statements" in docs
+    assert "Child support court orders" in docs
+    assert len(docs) == len(set(docs))
+
+
+def test_pdf_export_includes_checklist():
+    data = {
+        "checklist": [
+            {"label": "Last two pay stubs", "checked": True},
+            {"label": "W-2s", "checked": False},
+        ]
+    }
+    output = build_prequal_pdf(data)
+    assert b"[x] Last two pay stubs" in output
+    assert b"[ ] W-2s" in output

--- a/ui/documents.py
+++ b/ui/documents.py
@@ -1,0 +1,24 @@
+"""UI helpers for documentation checklist."""
+from __future__ import annotations
+import re
+import streamlit as st
+from core.checklist import build_document_checklist
+
+
+def _slug(label: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", label.lower()).strip("_")
+
+
+def render_document_checklist():
+    """Render an auto-generated checklist based on income cards."""
+    docs = build_document_checklist(st.session_state.get("income_cards", []))
+    st.session_state.setdefault("doc_checklist_state", {})
+    with st.expander("Documentation Checklist"):
+        for doc in docs:
+            key = _slug(doc)
+            checked = st.session_state["doc_checklist_state"].get(doc, False)
+            st.session_state["doc_checklist_state"][doc] = st.checkbox(doc, value=checked, key=f"doc_{key}")
+    st.session_state["doc_checklist"] = [
+        {"label": doc, "checked": st.session_state["doc_checklist_state"].get(doc, False)}
+        for doc in docs
+    ]


### PR DESCRIPTION
## Summary
- generate document checklist based on income cards
- render checklist with checkboxes in UI
- include checklist in PDF export stub and add coverage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6e1b85ef08331893f570d356faa30