### PR TITLE
feat: add audit logging and i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,10 @@ All notable changes to this project will be documented in this file.
 ## [2025-08-24]
 ### Added
 - Document checklist builder with checkboxes and PDF export support.
+
+## [2025-08-25]
+### Added
+- Critical warnings now require an override reason before PDF export and the reason is captured for audit.
+- Expanded disclaimer clarifies calculations are estimates and stresses AUS results, lender overlays, and income stability.
+- Simple audit log utility records user changes with timestamps.
+- Basic Spanish translations loaded from a JSON file with UI toggle support.

--- a/amalo/presets.py
+++ b/amalo/presets.py
@@ -1,8 +1,10 @@
 
-DISCLAIMER = ("This tool implements common calculations aligned with agency/investor practices "
-"(e.g., FNMA-style self-employed analyses, K‑1 distribution/liquidity checks, and program-aware MI/MIP/funding fees). "
-"It does not replace AUS findings, investor guides, or underwriter discretion. Use conservative income and document "
-"continuance, trends, and business liquidity as applicable.")
+DISCLAIMER = (
+    "This tool implements common calculations aligned with agency/investor practices "
+    "(e.g., FNMA-style self-employed analyses, K‑1 distribution/liquidity checks, and program-aware MI/MIP/funding fees). "
+    "Results are estimates only; AUS findings, lender overlays, and underwriter discretion prevail. "
+    "Income used must be stable and well documented—demonstrate continuance, trends, and business liquidity as applicable."
+)
 
 PROGRAM_PRESETS = {"Conventional":{"FE":31.0,"BE":45.0},"FHA":{"FE":31.0,"BE":50.0},
 "VA":{"FE":35.0,"BE":50.0},"USDA":{"FE":29.0,"BE":41.0},"Jumbo":{"FE":35.0,"BE":43.0}}

--- a/core/audit.py
+++ b/core/audit.py
@@ -1,0 +1,47 @@
+"""Simple audit log utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, List
+
+
+@dataclass
+class AuditEntry:
+    user: str
+    field: str
+    old_value: Any
+    new_value: Any
+    timestamp: datetime
+
+
+class AuditLog:
+    """In-memory audit log suitable for tests and small apps."""
+
+    def __init__(self) -> None:
+        self.entries: List[AuditEntry] = []
+
+    def record(self, user: str, field: str, old_value: Any, new_value: Any) -> None:
+        """Record a change to a field with user and timestamp."""
+        self.entries.append(
+            AuditEntry(
+                user=user,
+                field=field,
+                old_value=old_value,
+                new_value=new_value,
+                timestamp=datetime.utcnow(),
+            )
+        )
+
+    def as_dict(self) -> List[dict]:
+        """Return log entries as dictionaries for persistence or inspection."""
+        return [
+            {
+                "user": e.user,
+                "field": e.field,
+                "old": e.old_value,
+                "new": e.new_value,
+                "timestamp": e.timestamp.isoformat(),
+            }
+            for e in self.entries
+        ]

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -1,0 +1,25 @@
+"""Minimal internationalization helpers."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict
+
+TRANSLATIONS_DIR = Path(__file__).resolve().parents[1] / "translations"
+
+
+@lru_cache()
+def load_translations(lang: str) -> Dict[str, str]:
+    """Load translation mappings for the given language."""
+    path = TRANSLATIONS_DIR / f"{lang}.json"
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def t(key: str, lang: str) -> str:
+    """Translate ``key`` using the specified language."""
+    return load_translations(lang).get(key, key)

--- a/core/presets.py
+++ b/core/presets.py
@@ -1,8 +1,10 @@
 
-DISCLAIMER = ("This tool implements common calculations aligned with agency/investor practices "
-"(e.g., FNMA-style self-employed analyses, K‑1 distribution/liquidity checks, and program-aware MI/MIP/funding fees). "
-"It does not replace AUS findings, investor guides, or underwriter discretion. Use conservative income and document "
-"continuance, trends, and business liquidity as applicable.")
+DISCLAIMER = (
+    "This tool implements common calculations aligned with agency/investor practices "
+    "(e.g., FNMA-style self-employed analyses, K‑1 distribution/liquidity checks, and program-aware MI/MIP/funding fees). "
+    "Results are estimates only; AUS findings, lender overlays, and underwriter discretion prevail. "
+    "Income used must be stable and well documented—demonstrate continuance, trends, and business liquidity as applicable."
+)
 
 PROGRAM_PRESETS = {"Conventional":{"FE":31.0,"BE":45.0},"FHA":{"FE":31.0,"BE":50.0},
 "VA":{"FE":35.0,"BE":50.0},"USDA":{"FE":29.0,"BE":41.0},"Jumbo":{"FE":35.0,"BE":43.0}}

--- a/export/pdf_export.py
+++ b/export/pdf_export.py
@@ -9,11 +9,32 @@ def build_prequal_pdf(data: Dict[str, Any]) -> bytes:
     """Build a prequalification PDF from provided data.
 
     This stub encodes the documentation checklist into a plain text payload with
-    simple checkboxes. A real PDF implementation will replace this later.
+    simple checkboxes. A real PDF implementation will replace this later. If
+    critical warnings are present an ``override_reason`` is required and recorded
+    for audit purposes.
     """
+
+    warnings = data.get("warnings", [])
+    if any(w.get("severity") == "critical" for w in warnings):
+        override_reason = data.get("override_reason")
+        if not override_reason:
+            raise ValueError("override_reason required when critical warnings exist")
+    else:
+        override_reason = data.get("override_reason")
+
     checklist = data.get("checklist", [])
     lines = ["Documentation Checklist:"]
     for item in checklist:
         box = "[x]" if item.get("checked") else "[ ]"
         lines.append(f"{box} {item.get('label', '')}")
+
+    if warnings:
+        lines.append("Warnings:")
+        for w in warnings:
+            lines.append(f"{w.get('severity','')}: {w.get('message','')}")
+
+    if override_reason:
+        lines.append(f"Override Reason: {override_reason}")
+
+    lines.append(f"Disclaimer: {DISCLAIMER}")
     return "\n".join(lines).encode()

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,18 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.audit import AuditLog
+
+
+def test_audit_log_records_user_field_and_timestamp():
+    log = AuditLog()
+    log.record("alice", "income", 100, 200)
+    assert len(log.entries) == 1
+    entry = log.entries[0]
+    assert entry.user == "alice"
+    assert entry.field == "income"
+    assert entry.old_value == 100
+    assert entry.new_value == 200
+    assert entry.timestamp is not None

--- a/tests/test_pdf_override.py
+++ b/tests/test_pdf_override.py
@@ -1,0 +1,26 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+from export.pdf_export import build_prequal_pdf
+
+
+def test_requires_override_with_critical():
+    data = {
+        "warnings": [{"severity": "critical", "message": "K-1 used but distributions not verified."}],
+        "checklist": [],
+    }
+    with pytest.raises(ValueError):
+        build_prequal_pdf(data)
+
+
+def test_override_included():
+    data = {
+        "warnings": [{"severity": "critical", "message": "K-1 used but distributions not verified."}],
+        "override_reason": "Borrower provided liquidity statement",
+        "checklist": [],
+    }
+    output = build_prequal_pdf(data)
+    assert b"Override Reason: Borrower provided liquidity statement" in output

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,11 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from core.i18n import t
+
+
+def test_spanish_translation_loaded():
+    assert t("Program", "es") == "Programa"
+    assert t("UnknownKey", "es") == "UnknownKey"

--- a/translations/es.json
+++ b/translations/es.json
@@ -1,0 +1,12 @@
+{
+  "Program": "Programa",
+  "Lang": "Idioma",
+  "View": "Vista",
+  "data_entry": "Entrada de datos",
+  "dashboard": "Panel",
+  "max_qualifiers": "Calificadores máximos",
+  "Open Dashboard": "Abrir Panel",
+  "Open Max Qualifiers": "Abrir Calificadores Máximos",
+  "Total Income": "Ingreso Total",
+  "PITIA": "PITIA"
+}

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -1,5 +1,6 @@
 import streamlit as st
 from core.presets import PROGRAM_PRESETS
+from core.i18n import t
 
 
 def render_topbar():
@@ -16,10 +17,11 @@ def render_topbar():
     with st.container():
         st.markdown('<div class="amalo-topbar">', unsafe_allow_html=True)
         left, center, right = st.columns([1, 2, 1])
+        lang = st.session_state.get("ui_prefs", {}).get("language", "en")
         with left:
             st.markdown("**AMALO**")
         with center:
-            program = st.selectbox("Program", list(PROGRAM_PRESETS.keys()), key="program_name")
+            program = st.selectbox(t("Program", lang), list(PROGRAM_PRESETS.keys()), key="program_name")
             tgt = st.session_state.get("program_targets", {"fe_target": PROGRAM_PRESETS[program]["FE"], "be_target": PROGRAM_PRESETS[program]["BE"]})
             c1, c2, c3 = st.columns([1,1,1])
             fe = c1.number_input("FE Target", value=float(tgt.get("fe_target", PROGRAM_PRESETS[program]["FE"])), key="fe_target")
@@ -31,10 +33,10 @@ def render_topbar():
                 st.session_state["be_target"] = be
             tgt = {"fe_target": fe, "be_target": be}
         with right:
-            view_mode = st.radio("View", ["data_entry", "dashboard", "max_qualifiers"], horizontal=True, key="view_mode")
+            view_mode = st.radio(t("View", lang), ["data_entry", "dashboard", "max_qualifiers"], horizontal=True, key="view_mode")
             st.session_state.setdefault("ui_prefs", {})
             st.session_state["ui_prefs"].setdefault("language", "en")
-            st.session_state["ui_prefs"]["language"] = st.selectbox("Lang", ["en", "es"], key="ui_lang", index=["en","es"].index(st.session_state["ui_prefs"].get("language","en")))
+            st.session_state["ui_prefs"]["language"] = st.selectbox(t("Lang", lang), ["en", "es"], key="ui_lang", index=["en","es"].index(st.session_state["ui_prefs"].get("language","en")))
         st.markdown("</div>", unsafe_allow_html=True)
     st.session_state["program_targets"] = tgt
     return view_mode, tgt, program


### PR DESCRIPTION
## Summary
- require override reason for critical warnings in PDF export and record the reason
- expand disclaimer text about estimates, AUS results, and income stability
- add simple audit log utilities and JSON-driven Spanish translations with UI toggle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e3d4c7b0833181ec03aca3e30aa2