### PR TITLE
Remove unused variable in income calculator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ All notable changes to this project will be documented in this file.
 - Expanded disclaimer clarifies calculations are estimates and stresses AUS results, lender overlays, and income stability.
 - Simple audit log utility records user changes with timestamps.
 - Basic Spanish translations loaded from a JSON file with UI toggle support.
+
+## [2025-08-26]
+### Fixed
+- Removed unused variable in `default_gross_up_pct` to resolve linter warning.

--- a/core/calculators.py
+++ b/core/calculators.py
@@ -341,7 +341,6 @@ def default_gross_up_pct(income_type: str, program: str) -> float:
     """
 
     itype = (income_type or "").lower()
-    prog = (program or "").lower()
     if "social" in itype:
         return 25.0
     if "disability" in itype:


### PR DESCRIPTION
## Summary
- eliminate unused `prog` variable in default_gross_up_pct
- document change in changelog

## Testing
- `ruff check core/calculators.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecae8a088331b7fc299a45c6d7ce