### PR TITLE
Split semicolon-separated rule assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ All notable changes to this project will be documented in this file.
 - Expanded disclaimer clarifies calculations are estimates and stresses AUS results, lender overlays, and income stability.
 - Simple audit log utility records user changes with timestamps.
 - Basic Spanish translations loaded from a JSON file with UI toggle support.
+
+## [2025-08-26]
+### Fixed
+- Split semicolon-separated assignments in rules modules into separate lines to satisfy style checks.

--- a/amalo/rules.py
+++ b/amalo/rules.py
@@ -12,8 +12,10 @@ class RuleResult(BaseModel):
 def evaluate_rules(state: dict) -> List[RuleResult]:
     res: List[RuleResult] = []
     total_income=float(state.get("total_income",0.0))
-    FE=float(state.get("FE",0.0))*100; BE=float(state.get("BE",0.0))*100
-    target_FE=float(state.get("target_FE",31.0)); target_BE=float(state.get("target_BE",45.0))
+    FE = float(state.get("FE", 0.0)) * 100
+    BE = float(state.get("BE", 0.0)) * 100
+    target_FE = float(state.get("target_FE", 31.0))
+    target_BE = float(state.get("target_BE", 45.0))
 
     w2_meta=state.get("w2_meta",{})
     if w2_meta.get("var_included_lt_12", False):
@@ -100,7 +102,8 @@ def evaluate_rules(state: dict) -> List[RuleResult]:
         items = sorted(income_hist.items(), key=lambda kv: int(kv[0]))
         prev_year, prev_inc = items[-2]
         curr_year, curr_inc = items[-1]
-        prev_inc = float(prev_inc); curr_inc = float(curr_inc)
+        prev_inc = float(prev_inc)
+        curr_inc = float(curr_inc)
         if prev_inc > 0 and (prev_inc - curr_inc) / prev_inc > 0.20:
             res.append(
                 RuleResult(

--- a/core/rules.py
+++ b/core/rules.py
@@ -12,8 +12,10 @@ class RuleResult(BaseModel):
 def evaluate_rules(state: dict) -> List[RuleResult]:
     res: List[RuleResult] = []
     total_income=float(state.get("total_income",0.0))
-    FE=float(state.get("FE",0.0))*100; BE=float(state.get("BE",0.0))*100
-    target_FE=float(state.get("target_FE",31.0)); target_BE=float(state.get("target_BE",45.0))
+    FE = float(state.get("FE", 0.0)) * 100
+    BE = float(state.get("BE", 0.0)) * 100
+    target_FE = float(state.get("target_FE", 31.0))
+    target_BE = float(state.get("target_BE", 45.0))
 
     w2_meta=state.get("w2_meta",{})
     if w2_meta.get("var_included_lt_12", False):
@@ -100,7 +102,8 @@ def evaluate_rules(state: dict) -> List[RuleResult]:
         items = sorted(income_hist.items(), key=lambda kv: int(kv[0]))
         prev_year, prev_inc = items[-2]
         curr_year, curr_inc = items[-1]
-        prev_inc = float(prev_inc); curr_inc = float(curr_inc)
+        prev_inc = float(prev_inc)
+        curr_inc = float(curr_inc)
         if prev_inc > 0 and (prev_inc - curr_inc) / prev_inc > 0.20:
             res.append(
                 RuleResult(


### PR DESCRIPTION
## Summary
- separate FE/BE and target ratio assignments onto their own lines in rule modules
- avoid chaining casts for income history entries to comply with style checks
- document rule formatting fix in changelog

## Testing
- `ruff check amalo/rules.py core/rules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecad8b44833184b9f3f08c6fd45f