### PR TITLE
Remove unused Optional import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ All notable changes to this project will be documented in this file.
 - Expanded disclaimer clarifies calculations are estimates and stresses AUS results, lender overlays, and income stability.
 - Simple audit log utility records user changes with timestamps.
 - Basic Spanish translations loaded from a JSON file with UI toggle support.
+
+## [2025-08-26]
+### Removed
+- Unused `Optional` import from `amalo.models`.

--- a/amalo/models.py
+++ b/amalo/models.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from typing import Optional
 
 
 class W2Row(BaseModel):


### PR DESCRIPTION
## Summary
- remove unused `Optional` import from models
- document removal in changelog

## Testing
- `ruff check amalo/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecaae5588331a69e9e0c04ca4587