### PR TITLE
style: expand branding conditionals in pdf export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,7 @@ All notable changes to this project will be documented in this file.
 - Expanded disclaimer clarifies calculations are estimates and stresses AUS results, lender overlays, and income stability.
 - Simple audit log utility records user changes with timestamps.
 - Basic Spanish translations loaded from a JSON file with UI toggle support.
+
+## [2025-08-26]
+### Fixed
+- Expanded single-line conditionals in `amalo/pdf_export.py` to multi-line blocks to satisfy style checks.

--- a/amalo/pdf_export.py
+++ b/amalo/pdf_export.py
@@ -14,8 +14,20 @@ def build_prequal_pdf(out_path: str, branding: dict, summary: dict, incomes_tabl
     story = []
     title = branding.get("title","Prequalification Summary")
     story += [Paragraph(f"<b>{title}</b>", styles['Title']), Spacer(1,6)]
-    if branding.get("mlo"): story.append(Paragraph(f"MLO: {branding['mlo']}  |  NMLS: {branding.get('nmls','')}", styles['Normal']))
-    if branding.get("contact"): story.append(Paragraph(f"Contact: {branding['contact']}", styles['Normal']))
+    if branding.get("mlo"):
+        story.append(
+            Paragraph(
+                f"MLO: {branding['mlo']}  |  NMLS: {branding.get('nmls','')}",
+                styles['Normal'],
+            )
+        )
+    if branding.get("contact"):
+        story.append(
+            Paragraph(
+                f"Contact: {branding['contact']}",
+                styles['Normal'],
+            )
+        )
     story += [Spacer(1, 12)]
     ds = summary.get("deal_snapshot", {})
     deal_rows = [[k, f"{v}"] for k,v in ds.items()]


### PR DESCRIPTION
## Summary
- expand inline branding conditionals in pdf export into multi-line blocks
- document the pdf export style fix in changelog

## Testing
- `ruff check amalo/pdf_export.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6ecabef1c8331a1d068a33a50e74f