### PR TITLE
Avoid persisting widget keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,7 @@ All notable changes to this project will be documented in this file.
 - CI pipeline now checks formatting with Black and lints with Ruff.
 
 
+
+## [2025-08-28]
+### Fixed
+- Avoid persisting Streamlit widget keys so buttons like "Add Income Card" no longer crash on startup.

--- a/core/state.py
+++ b/core/state.py
@@ -6,6 +6,30 @@ import streamlit as st
 
 SESSION_FILE = "session_data.json"
 
+# Only persist a curated subset of ``st.session_state`` keys. Streamlit
+# widgets such as buttons inject their own keys (e.g. ``add_income_card``)
+# into ``session_state`` when interacted with. Persisting those ephemeral
+# keys causes ``StreamlitAPIException`` on the next run because widgets with
+# the same keys disallow manual assignment. To avoid this, limit persistence
+# to known application data keys.
+PERSISTED_KEYS = {
+    "view_mode",
+    "program_name",
+    "program_targets",
+    "ui_prefs",
+    "housing",
+    "housing_calc",
+    "income_cards",
+    "debt_cards",
+    "doc_checklist_state",
+    "doc_checklist",
+    "conv_mi_table",
+    "fha_table",
+    "va_table",
+    "usda_table",
+    "w2_rows",
+}
+
 
 def _serializable(value: Any) -> bool:
     return isinstance(value, (int, float, str, bool, list, dict))
@@ -19,7 +43,8 @@ def load_state() -> None:
         with open(SESSION_FILE, "r", encoding="utf-8") as f:
             data = json.load(f)
         for key, val in data.items():
-            st.session_state.setdefault(key, val)
+            if key in PERSISTED_KEYS:
+                st.session_state.setdefault(key, val)
     except Exception:
         pass
 
@@ -27,7 +52,11 @@ def load_state() -> None:
 def save_state() -> None:
     """Persist serializable session state to ``SESSION_FILE``."""
     try:
-        data = {k: v for k, v in st.session_state.items() if _serializable(v)}
+        data = {
+            k: v
+            for k, v in st.session_state.items()
+            if k in PERSISTED_KEYS and _serializable(v)
+        }
         with open(SESSION_FILE, "w", encoding="utf-8") as f:
             json.dump(data, f)
     except Exception:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,25 @@
+import json
+import streamlit as st
+from core import state
+
+
+def test_save_state_ignores_widget_keys(tmp_path, monkeypatch):
+    file = tmp_path / "session.json"
+    monkeypatch.setattr(state, "SESSION_FILE", str(file))
+    st.session_state.clear()
+    st.session_state["income_cards"] = []
+    st.session_state["add_income_card"] = True
+    state.save_state()
+    data = json.loads(file.read_text())
+    assert "add_income_card" not in data
+    assert "income_cards" in data
+
+
+def test_load_state_ignores_widget_keys(tmp_path, monkeypatch):
+    file = tmp_path / "session.json"
+    file.write_text(json.dumps({"income_cards": [], "add_income_card": True}))
+    monkeypatch.setattr(state, "SESSION_FILE", str(file))
+    st.session_state.clear()
+    state.load_state()
+    assert "income_cards" in st.session_state
+    assert "add_income_card" not in st.session_state


### PR DESCRIPTION
## Summary
- prevent Streamlit from saving widget-only keys into session data
- cover state persistence filter with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6f7833ac4833194dba126d5b7f525