### PR TITLE
Add what-if, reserve, and DSCR calculators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,3 +71,8 @@ All notable changes to this project will be documented in this file.
 ## [2025-08-29]
 ### Fixed
 - Updated CI workflow to run `ruff check .` to fix "unrecognized subcommand '.'" errors.
+
+## [2025-08-30]
+### Added
+- What-if calculator provides quick toggles for down payment, rate, and monthly debt changes.
+- Reserve requirement and DSCR helpers support investment property analyses.

--- a/core/calculators.py
+++ b/core/calculators.py
@@ -3,6 +3,31 @@ import math
 import pandas as pd
 
 
+# ---------------------------------------------------------------------------
+# Helper constants for additional calculators
+# ---------------------------------------------------------------------------
+
+# Default reserve requirements expressed in months of PITIA by loan program and
+# property type. Values are intentionally conservative but easily adjustable by
+# callers if guidelines change.
+RESERVE_REQUIREMENTS = {
+    "Conventional": {"primary": 2, "investment": 6},
+    "FHA": {"primary": 1, "investment": 3},
+    "VA": {"primary": 2, "investment": 6},
+    "USDA": {"primary": 1, "investment": 3},
+}
+
+# Typical minimum DSCR ratios by program.  Most agency products require the
+# property to break even (ratio >= 1.0) while some portfolio products may have
+# higher thresholds.
+DSCR_MINIMUMS = {
+    "Conventional": 1.0,
+    "FHA": 1.0,
+    "VA": 1.0,
+    "USDA": 1.0,
+}
+
+
 def nz(x, default=0.0):
     """Return a float for ``x`` or a fallback value.
 
@@ -875,4 +900,104 @@ def max_qualifying_loan(
         "base_loan": base,
         "adjusted_loan": fees["adjusted_loan"],
         "purchase_price": purchase_price,
+    }
+
+
+# ---------------------------------------------------------------------------
+# What‑if, reserves and DSCR helpers
+# ---------------------------------------------------------------------------
+
+
+def reserve_requirement(pitia: float, property_type: str, program: str) -> float:
+    """Return required reserves in dollars for the given scenario.
+
+    ``pitia`` is the monthly payment (principal, interest, taxes, insurance and
+    association dues). ``property_type`` should be ``"primary"`` or
+    ``"investment"``. ``program`` is the loan program such as "Conventional" or
+    "FHA". The function multiplies ``pitia`` by the guideline number of months
+    for the combination; unknown inputs yield ``0``.
+    """
+
+    prop = (property_type or "").lower()
+    months = RESERVE_REQUIREMENTS.get(program, {}).get(prop, 0)
+    return months * nz(pitia)
+
+
+def dscr(monthly_rent: float, pitia: float, program: str = "Conventional") -> dict:
+    """Calculate Debt Service Coverage Ratio and flag if below minimum.
+
+    Returns a dictionary with the computed ratio under ``dscr`` and a boolean
+    ``below_minimum`` indicating whether the ratio falls short of the typical
+    program threshold.
+    """
+
+    ratio = 0.0 if nz(pitia) == 0 else nz(monthly_rent) / nz(pitia)
+    min_ratio = DSCR_MINIMUMS.get(program, 1.0)
+    return {"dscr": ratio, "below_minimum": ratio < min_ratio, "minimum": min_ratio}
+
+
+def what_if_max_qualifying(
+    total_income,
+    other_debts,
+    taxes_ins_hoa_mi,
+    fe_target,
+    be_target,
+    rate_pct,
+    term_years,
+    down_payment_amt,
+    program,
+    conv_mi_tbl,
+    fha_tables,
+    va_tbl,
+    usda_tbl,
+    finance_upfront,
+    first_use_va,
+    fico_bucket,
+):
+    """Evaluate max loan and DTI under several quick adjustment scenarios.
+
+    The baseline scenario uses the provided inputs.  Additional scenarios apply
+    common what‑if adjustments to highlight their impact:
+
+    - ``down_payment_plus_10k`` adds $10,000 to the down payment.
+    - ``rate_plus_0.25`` increases the interest rate by 0.25 percentage points.
+    - ``debt_plus_300`` adds $300 to the other monthly debt load.
+    """
+
+    def scenario(dp, rate, debts):
+        res = max_qualifying_loan(
+            total_income,
+            debts,
+            taxes_ins_hoa_mi,
+            fe_target,
+            be_target,
+            rate,
+            term_years,
+            dp,
+            program,
+            conv_mi_tbl,
+            fha_tables,
+            va_tbl,
+            usda_tbl,
+            finance_upfront,
+            first_use_va,
+            fico_bucket,
+        )
+        fe, be = dti(
+            res["max_pi"] + taxes_ins_hoa_mi,
+            res["max_pi"] + taxes_ins_hoa_mi + debts,
+            total_income,
+        )
+        return {"fe_dti": fe, "be_dti": be, "max_loan": res["adjusted_loan"]}
+
+    base = scenario(down_payment_amt, rate_pct, other_debts)
+    dp_up = scenario(down_payment_amt + 10_000, rate_pct, other_debts)
+    rate_up = scenario(down_payment_amt, rate_pct + 0.25, other_debts)
+    debt_up = scenario(down_payment_amt, rate_pct, other_debts + 300)
+
+    return {
+        "base": base,
+        "down_payment_plus_10k": dp_up,
+        "rate_plus_0.25": rate_up,
+        "debt_plus_300": debt_up,
     }

--- a/tests/test_new_calculators.py
+++ b/tests/test_new_calculators.py
@@ -1,0 +1,42 @@
+from core.calculators import reserve_requirement, dscr, what_if_max_qualifying
+from core.presets import CONV_MI_BANDS, FHA_TABLES, VA_TABLE, USDA_TABLE
+
+
+def test_reserve_requirement_primary_investment():
+    assert reserve_requirement(2000, "primary", "Conventional") == 4000
+    assert reserve_requirement(2000, "investment", "Conventional") == 12000
+
+
+def test_dscr_flagging():
+    low = dscr(1800, 2000, "Conventional")
+    high = dscr(2200, 2000, "Conventional")
+    assert low["below_minimum"] is True
+    assert high["below_minimum"] is False
+
+
+def test_what_if_max_qualifying_changes():
+    res = what_if_max_qualifying(
+        10000,
+        500,
+        300,
+        31,
+        45,
+        6.5,
+        30,
+        20000,
+        "Conventional",
+        CONV_MI_BANDS,
+        FHA_TABLES,
+        VA_TABLE,
+        USDA_TABLE,
+        True,
+        True,
+        ">=740",
+    )
+    base = res["base"]
+    dp = res["down_payment_plus_10k"]
+    rate = res["rate_plus_0.25"]
+    debt = res["debt_plus_300"]
+    assert dp["max_loan"] >= base["max_loan"]
+    assert rate["max_loan"] < base["max_loan"]
+    assert debt["be_dti"] > base["be_dti"]

--- a/ui/max_qualifiers.py
+++ b/ui/max_qualifiers.py
@@ -1,5 +1,5 @@
 import streamlit as st
-from core.calculators import max_qualifying_loan
+from core.calculators import dti, max_qualifying_loan, what_if_max_qualifying
 from core.presets import CONV_MI_BANDS, FHA_TABLES, VA_TABLE, USDA_TABLE
 from app import fico_to_bucket
 
@@ -35,6 +35,49 @@ def render_max_qualifiers_view():
         True,
         fico_to_bucket(st.session_state.get("housing", {}).get("credit_score")),
     )
+    fe, be = dti(
+        res["max_pi"] + tax_ins, res["max_pi"] + tax_ins + other_debts, tot_inc
+    )
     st.caption(
         f"Base Loan: ${res['base_loan']:,.0f} • Adjusted Loan: ${res['adjusted_loan']:,.0f} • Purchase Price: ${res['purchase_price']:,.0f}"
     )
+    st.caption(f"FE DTI: {fe*100:.2f}% • BE DTI: {be*100:.2f}%")
+
+    c1, c2, c3 = st.columns(3)
+    with c1:
+        more_down = st.checkbox("Increase down payment by $10k", key="mq_more_down")
+    with c2:
+        more_rate = st.checkbox("Increase rate by 0.25%", key="mq_more_rate")
+    with c3:
+        more_debt = st.checkbox("Add $300 monthly debt", key="mq_more_debt")
+
+    if more_down or more_rate or more_debt:
+        scenarios = what_if_max_qualifying(
+            tot_inc,
+            other_debts,
+            tax_ins,
+            targets.get("fe_target", 0.0),
+            targets.get("be_target", 0.0),
+            rate,
+            term,
+            down,
+            program,
+            st.session_state.get("conv_mi_table", CONV_MI_BANDS),
+            st.session_state.get("fha_table", FHA_TABLES),
+            st.session_state.get("va_table", VA_TABLE),
+            st.session_state.get("usda_table", USDA_TABLE),
+            True,
+            True,
+            fico_to_bucket(st.session_state.get("housing", {}).get("credit_score")),
+        )
+        key = "base"
+        if more_down:
+            key = "down_payment_plus_10k"
+        if more_rate:
+            key = "rate_plus_0.25"
+        if more_debt:
+            key = "debt_plus_300"
+        alt = scenarios[key]
+        st.caption(
+            f"What-If Max Loan: ${alt['max_loan']:,.0f} • FE DTI: {alt['fe_dti']*100:.2f}% • BE DTI: {alt['be_dti']*100:.2f}%"
+        )


### PR DESCRIPTION
## Summary
- add default reserve and DSCR thresholds with helper functions
- implement what-if max loan calculator and integrate toggles in UI
- expose reserve and DSCR utilities with tests

## Testing
- `python -m black core/calculators.py amalo/calculators.py ui/max_qualifiers.py tests/test_new_calculators.py`
- `python -m ruff check core/calculators.py amalo/calculators.py ui/max_qualifiers.py tests/test_new_calculators.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a6fa47f554833185df54e36dc79638