### PR TITLE
fix: decouple view mode from top bar widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 - What-if calculator provides quick toggles for down payment, rate, and monthly debt changes.
 - Reserve requirement and DSCR helpers support investment property analyses.
+
+## [0.1.1] - 2025-08-31
+### Fixed
+- Bottom bar view switches no longer raise a ``StreamlitAPIException`` by separating
+  widget and session state keys.

--- a/core/version.py
+++ b/core/version.py
@@ -3,4 +3,4 @@ from importlib import metadata
 try:
     __version__ = metadata.version("amalo")
 except metadata.PackageNotFoundError:  # pragma: no cover - during local dev
-    __version__ = "0.1.0"
+    __version__ = "0.1.1"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ from setuptools import setup, find_packages
 
 setup(
     name="amalo",
-    version="0.1.0",
+    version="0.1.1",
     packages=find_packages(include=["amalo", "amalo.*"]),
 )

--- a/ui/topbar.py
+++ b/ui/topbar.py
@@ -50,12 +50,23 @@ def render_topbar():
                 st.session_state["be_target"] = be
             tgt = {"fe_target": fe, "be_target": be}
         with right:
+            # ``st.radio`` will manage the value for its ``key`` inside
+            # ``st.session_state``.  Streamlit 1.30+ forbids assigning to that
+            # key again within the same script run.  Previously the bottom bar
+            # attempted to change ``view_mode`` directly which triggered a
+            # ``StreamlitAPIException``.  To allow programmatic updates, use a
+            # separate key for the widget and synchronize it with our own
+            # ``view_mode`` entry.
+            st.session_state.setdefault("view_mode", "data_entry")
+            st.session_state["view_mode_radio"] = st.session_state["view_mode"]
             view_mode = st.radio(
                 t("View", lang),
                 ["data_entry", "dashboard", "max_qualifiers"],
                 horizontal=True,
-                key="view_mode",
+                key="view_mode_radio",
             )
+            st.session_state["view_mode"] = view_mode
+
             st.session_state.setdefault("ui_prefs", {})
             st.session_state["ui_prefs"].setdefault("language", "en")
             st.session_state["ui_prefs"]["language"] = st.selectbox(


### PR DESCRIPTION
## Summary
- avoid StreamlitAPIException by keeping `view_mode` separate from top bar radio widget
- bump version to 0.1.1
- document fix in changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6fce640a083319b1dc830d987fde2